### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # grunt-broccoli [![Build Status](https://travis-ci.org/quandl/grunt-broccoli.svg?branch=master)](https://travis-ci.org/quandl/grunt-broccoli)
 
+## Deprecated
+This module has been deprecated in favor of [grunt-broccoli ^1.0.0](https://github.com/EmberSherpa/grunt-broccoli)
+
 Allows you to execute your Broccoli configurations as Grunt tasks. [Broccoli](https://github.com/joliss/broccoli) is an asset pipeline that allows for incremental builds. Broccoli rebuilds individual files instead of the entire project as Grunt watch does. Checkout the [Broccoli Sample App](https://github.com/joliss/broccoli-sample-app).
 
 


### PR DESCRIPTION
Hey there,

I tried first to reach out through an issue or an email, but it looks like the issue tracker was closed, and there was no email on your profile, so I thought I'd go with a PR.

I recently joined the [grunt-broccoli](https://github.com/EmberSherpa/grunt-broccoli) project, and just now pushed a version 1.0.0 of that module to npm. It depends on the latest version of Broccoli, cleans up the API a little and added a new feature. To me (who's been using Broccoli outside of ember-cli for several years), there seems to be some confusion around which grunt-broccoli module was the right one to use. There are multiple forks on npm, since grunt-broccoli itself hadn't been updated for some time.

Anyway, I think it would be great to consolidate our efforts in [EmberSherpa/grunt-broccoli](https://github.com/EmberSherpa/grunt-broccoli), and work together to make that module the best it can be!

Best regards,
Fredrik